### PR TITLE
Modern .NET updates

### DIFF
--- a/Source/EndianBinaryIO.csproj
+++ b/Source/EndianBinaryIO.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <OutputType>Library</OutputType>
     <RootNamespace>Kermalis.EndianBinaryIO</RootNamespace>
     <Authors>Kermalis</Authors>
@@ -15,7 +15,7 @@
     <NoWarn />
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     
-    <Description>A .NET 5 library that can read and write primitives, enums, arrays, and strings to streams and byte arrays using specified endianness, string encoding, and boolean sizes.
+    <Description>A .NET Core library compatible with any newer .NET SDK versions. This library can read and write primitives, enums, arrays, and strings to streams and byte arrays using specified endianness, string encoding, and boolean sizes.
 Objects can also be read from/written to streams via reflection and attributes.
 Project URL ― https://github.com/Kermalis/EndianBinaryIO</Description>
     <PackageProjectUrl>https://github.com/Kermalis/EndianBinaryIO</PackageProjectUrl>

--- a/Source/EndianBinaryIO.csproj
+++ b/Source/EndianBinaryIO.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <OutputType>Library</OutputType>
     <RootNamespace>Kermalis.EndianBinaryIO</RootNamespace>
     <Authors>Kermalis</Authors>
@@ -15,7 +15,7 @@
     <NoWarn />
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     
-    <Description>A .NET Standard library that can read and write primitives, enums, arrays, and strings to streams and byte arrays using specified endianness, string encoding, and boolean sizes.
+    <Description>A .NET 5 library that can read and write primitives, enums, arrays, and strings to streams and byte arrays using specified endianness, string encoding, and boolean sizes.
 Objects can also be read from/written to streams via reflection and attributes.
 Project URL ― https://github.com/Kermalis/EndianBinaryIO</Description>
     <PackageProjectUrl>https://github.com/Kermalis/EndianBinaryIO</PackageProjectUrl>

--- a/Source/EndianBinaryReader.cs
+++ b/Source/EndianBinaryReader.cs
@@ -51,7 +51,7 @@ namespace Kermalis.EndianBinaryIO
             BaseStream = baseStream;
             Endianness = endianness;
             BooleanSize = booleanSize;
-            Encoding = Encoding.Default;
+            Encoding = Encoding.ASCII;
         }
         public EndianBinaryReader(Stream baseStream, Encoding encoding, Endianness endianness = Endianness.LittleEndian, BooleanSize booleanSize = BooleanSize.U8)
         {

--- a/Testing/EndianBinaryTesting.csproj
+++ b/Testing/EndianBinaryTesting.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <RootNamespace>Kermalis.EndianBinaryIOTests</RootNamespace>
     <Authors>Kermalis</Authors>
     <Copyright>Kermalis</Copyright>
@@ -12,9 +12,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
Upgraded to .NET Core 3.1, changed encoding from Default to ASCII to fix issues regarding DSE reading. (Encoding stuff will be removed in the upcoming PR anyways)